### PR TITLE
fix: exclude false positive gitleak

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,2 @@
+[[allowlist.files]]
+path = "docker/haproxy.pem"


### PR DESCRIPTION
# Pull Request Description

exclude false positive gitleak (pem file is a dummy key from the original refimpl)

Fixes #(issue)

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
