### PR TITLE
perf: reduce files included in build of custom-verifier

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,11 @@ RUN echo "NODE_EXTRA_CA_CERTS=$NODE_EXTRA_CA_CERTS"
 
 RUN npm ci
 
-COPY . .
+COPY layouts layouts
+COPY pages pages
+COPY public public
+COPY server server
+COPY app.vue nuxt.config.ts tsconfig.json ./
 
 ENV HOST_API=http://eudi-verifier
 RUN npm run build


### PR DESCRIPTION
By limiting the amount of files we include in the Docker build we avoid rebuilding the image due to irrelevant changes. For instance, we generally do not need to rebuild the Docker image when something has changed in the ./docker directory.

This reduces the build time of the custom-verifier Docker image.

# Pull Request Description

Please include a summary of the change and which issue is fixed or added.
Please also include relevant motivation and context.
List any dependencies that are required for this change.

Fixes #(issue)

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
