### PR TITLE
test: add ability to run test suite once

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,21 @@ you may need to modify the location of the backend.
 ```bash
 env HOST_API=http://localhost:8080 npm run dev
 ```
+
+## Running tests
+
+To run the automated test suite, run:
+
+```bash
+npm run test
+```
+
+**Note:** On a development machine,
+the above will start the tests in watch mode.
+That is, the tests will rerun automatically on any file change.
+
+To run the test suite only once, run:
+
+```bash
+npm run test:once
+```

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "preview": "nuxt preview",
     "postinstall": "nuxt prepare",
     "test": "vitest",
+    "test:once": "vitest run",
     "test:ui": "vitest --ui",
     "test:e2e": "playwright test"
   },


### PR DESCRIPTION
On a development machine, `npm run test` will enter watch mode and repeatedly rerun the test suite on any file change. This is generally useful, but sometimes we want to run the test suite only once and then exit - for instance, when used to guard pushing changes to a remote repository. To suppport this use case, and others, we introduce the `npm run test:once` command:

	npm run test:once && git push

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
