### PR TITLE
feat: optionally skip Megalinter output sanitization

### DIFF
--- a/development/code_quality.sh
+++ b/development/code_quality.sh
@@ -51,6 +51,7 @@ lint_and_format() {
   docker run --rm --volume "$(pwd)":/repo \
     -e MEGALINTER_CONFIG='development/megalinter.yml' \
     -e DEFAULT_WORKSPACE=${MEGALINTER_DEF_WORKSPACE} \
+    -e SKIP_LINTER_OUTPUT_SANITIZATION="${MEGALINTER_SKIP_LINTER_OUTPUT_SANITIZATION}" \
     -e LOG_LEVEL=INFO \
     ghcr.io/oxsecurity/megalinter-javascript:v8.7.0
   store_exit_code "$?" "Lint" \

--- a/development/code_quality.sh
+++ b/development/code_quality.sh
@@ -48,8 +48,14 @@ store_exit_code() {
 lint_and_format() {
   export MEGALINTER_DEF_WORKSPACE='/repo'
   print_header 'LINTER HEALTH (MEGALINTER)'
-  docker run --rm --volume "$(pwd)":/repo -e MEGALINTER_CONFIG='development/megalinter.yml' -e DEFAULT_WORKSPACE=${MEGALINTER_DEF_WORKSPACE} -e LOG_LEVEL=INFO ghcr.io/oxsecurity/megalinter-javascript:v8.7.0
-  store_exit_code "$?" "Lint" "${MISSING} ${RED}Lint check failed, see logs (std out and/or ./megalinter-reports) and fix problems.${NC}\n" "${GREEN}${CHECKMARK}${CHECKMARK} Lint check passed${NC}\n"
+  docker run --rm --volume "$(pwd)":/repo \
+    -e MEGALINTER_CONFIG='development/megalinter.yml' \
+    -e DEFAULT_WORKSPACE=${MEGALINTER_DEF_WORKSPACE} \
+    -e LOG_LEVEL=INFO \
+    ghcr.io/oxsecurity/megalinter-javascript:v8.7.0
+  store_exit_code "$?" "Lint" \
+    "${MISSING} ${RED}Lint check failed, see logs (std out and/or ./megalinter-reports) and fix problems.${NC}\n" \
+    "${GREEN}${CHECKMARK}${CHECKMARK} Lint check passed${NC}\n"
   printf '\n\n'
 }
 
@@ -60,11 +66,18 @@ commit() {
   print_header 'COMMIT HEALTH (CONFORM)'
 
   if [[ "$(git rev-list --count ${compareToBranch}..)" == 0 ]]; then
-    printf "%s" "${GREEN} No commits found in current branch: ${YELLOW}${currentBranch}${NC}, compared to: ${YELLOW}${compareToBranch}${NC} ${NC}"
-    store_exit_code "$?" "Commit" "${MISSING} ${RED}Commit check count failed, see logs (std out) and fix problems.${NC}\n" "${YELLOW}${CHECKMARK}${CHECKMARK} Commit check skipped, no new commits found in current branch: ${YELLOW}${currentBranch}${NC}\n"
+    printf "%s" \
+      "${GREEN} No commits found in current branch: ${YELLOW}${currentBranch}${NC}, compared to: ${YELLOW}${compareToBranch}${NC} ${NC}"
+    store_exit_code "$?" "Commit" \
+      "${MISSING} ${RED}Commit check count failed, see logs (std out) and fix problems.${NC}\n" \
+      "${YELLOW}${CHECKMARK}${CHECKMARK} Commit check skipped, no new commits found in current branch: ${YELLOW}${currentBranch}${NC}\n"
   else
-    docker run --rm -i --volume "$(pwd)":/repo -w /repo ghcr.io/siderolabs/conform:v0.1.0-alpha.30-2-gfadbbb4 enforce --base-branch="${compareToBranch}"
-    store_exit_code "$?" "Commit" "${MISSING} ${RED}Commit check failed, see logs (std out) and fix problems.${NC}\n" "${GREEN}${CHECKMARK}${CHECKMARK} Commit check passed${NC}\n"
+    docker run --rm -i --volume "$(pwd)":/repo -w /repo \
+      ghcr.io/siderolabs/conform:v0.1.0-alpha.30-2-gfadbbb4 \
+      enforce --base-branch="${compareToBranch}"
+    store_exit_code "$?" "Commit" \
+      "${MISSING} ${RED}Commit check failed, see logs (std out) and fix problems.${NC}\n" \
+      "${GREEN}${CHECKMARK}${CHECKMARK} Commit check passed${NC}\n"
   fi
 
   printf '\n\n'


### PR DESCRIPTION
By skipping the Megalinter output sanitization, we can dramatically
reduce the total execution time of Megalinter when running behind a
corporate proxy. On my machine the runtime is reduced from 9 minutes to
a few seconds.

The 9 minute wait is caused by Megalinter trying to fetch the default
Gitleaks rules from GitHub. When running behind a corporate proxy this
can fail if Megalinter does not route the request through the proxy. On
my machine it takes about 9 minutes for the operation to timeout.

To skip the Megalinter output sanitization, invoke the code quality
script like so:

	env MEGALINTER_SKIP_LINTER_OUTPUT_SANITIZATION=true ./development/code_quality.sh

Note: By skipping the sanitization there is a risk that the log output
will contain secrets. However, the code quality script is only intended
to run on development machines, so the impact should be pretty small.
Especially since it is an opt-in choice. Also, on our CI systems we
invoke Megalinter by other means, so it is not an issue there.

See: https://megalinter.io/8/config-variables/
See: https://github.com/oxsecurity/megalinter/blob/45603f3c87c8c207f34e28abbde9c2e949d8e73f/megalinter/logger.py#L231
See: https://github.com/oxsecurity/megalinter/blob/45603f3c87c8c207f34e28abbde9c2e949d8e73f/megalinter/logger.py#L194
## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
