### PR TITLE
fix: fetch wallet-ecosystem before checkout

### DIFF
--- a/docker/scripts/wallet-ecosystem-http.sh
+++ b/docker/scripts/wallet-ecosystem-http.sh
@@ -66,6 +66,7 @@ fi
 cd "$DOCKER_DIR/wallet-ecosystem"
 log "Starting wallet ecosystem..."
 git reset --hard HEAD && git clean -fd
+git fetch --prune
 # Pin to stable version
 git checkout v0.3.0
 git submodule foreach --recursive 'git reset --hard HEAD && git clean -fd'


### PR DESCRIPTION
This ensures that the reference 'v0.3.0' exists locally. Without this
step the checkout will fail unless the reference has already been
fetched by other means

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
