### PR TITLE
ci(lint): extend commitlint length

### DIFF
--- a/.conform.yaml
+++ b/.conform.yaml
@@ -29,3 +29,4 @@ policies:
             "release",
           ]
         scopes: [".*"]
+        descriptionLength: 92


### PR DESCRIPTION
The default length has shown to be to short for some autotools (renovate, dependabot) at times, so we just raise this. 

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
