### PR TITLE
fix: change copyright owner of .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,4 @@
-; SPDX-FileCopyrightText: 2025 diggsweden/rest-api-profil-lint-processor
+; SPDX-FileCopyrightText: 2025 Digg - Agency for Digital Government
 ;
 ; SPDX-License-Identifier: CC0-1.0
 


### PR DESCRIPTION
The set owner 'diggsweden/rest-api-profil-lint-processor' is obviously a copy paste mistake. I did a quick search of all copyright owner texts in the repository and opted for the same used in the Megalinter configuration file.

Here is the command used to find all copyright texts:

	grep --no-filename -r -e 'SPDX-FileCopyrightText' . \
		| sed -E 's|.*(SPDX-FileCopyrightText)|\1|' \
		| sort \
		| uniq -c \
		| sort -r

See: development/megalinter.yml

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
