### PR TITLE
feat: allow customization of commit lint baseline

### DIFF
--- a/development/code_quality.sh
+++ b/development/code_quality.sh
@@ -61,12 +61,12 @@ lint_and_format() {
 }
 
 commit() {
-  local compareToBranch='main'
+  local compareToBranch="${COMMIT_COMPARE_TO_BRANCH:-main}"
   local currentBranch
   currentBranch=$(git branch --show-current)
   print_header 'COMMIT HEALTH (CONFORM)'
 
-  if [[ "$(git rev-list --count ${compareToBranch}..)" == 0 ]]; then
+  if [[ "$(git rev-list --count "${compareToBranch}"..)" == 0 ]]; then
     printf "%s" \
       "${GREEN} No commits found in current branch: ${YELLOW}${currentBranch}${NC}, compared to: ${YELLOW}${compareToBranch}${NC} ${NC}"
     store_exit_code "$?" "Commit" \


### PR DESCRIPTION
Normally we want to compare against the 'main' branch when running the commit lint. However, the mainline is not always called 'main'. For instance, when doing development on a forked version of the repository, the 'main' branch is probably on the origin and the mainline of the forked repo is called something else. By using an environment variable we allow for comparing with the mainline of the forked reposistory.

Assuming you have a remote named 'my-fork' you can run the commit lint using the 'main' branch of your fork using the command below:

	 env COMMIT_COMPARE_TO_BRANCH=my-fork/main ./development/code_quality.sh

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
