### PR TITLE
fix(actions): add version convention

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -21,7 +21,7 @@ jobs:
           egress-policy: audit
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5.0.0 #v5.0.0
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }} # https://github.com/actions/checkout/issues/426

--- a/.github/workflows/dependencyreview.yml
+++ b/.github/workflows/dependencyreview.yml
@@ -15,14 +15,14 @@ jobs:
     if: github.event_name == 'pull_request'
     steps:
       - name: Harden GitHub runner
-        uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
+        uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 #v2.10.1
         with:
           egress-policy: audit
 
       - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
 
       - name: Dependency Review
-        uses: actions/dependency-review-action@4081bf99e2866ebe428fc0477b69eb4fcda7220a # v4.4.0
+        uses: actions/dependency-review-action@4081bf99e2866ebe428fc0477b69eb4fcda7220a #v4.4.0
         with:
           fail-on-severity: "critical"

--- a/.github/workflows/misclint.yml
+++ b/.github/workflows/misclint.yml
@@ -27,7 +27,7 @@ jobs:
           egress-policy: audit
 
       - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
         with:
           fetch-depth: 10
 

--- a/.github/workflows/publishimage.yml
+++ b/.github/workflows/publishimage.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v4 #v4.4.0
         with:
           node-version: 20
 
@@ -34,7 +34,7 @@ jobs:
         run: npm run generate
 
       - name: Configure QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v3 #v3.6.0
 
       - name: Configure Docker Buildx
         id: buildx
@@ -45,7 +45,7 @@ jobs:
           echo "Platforms: ${{ steps.buildx.outputs.platforms }}"
 
       - name: Authenticate with Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v3 #v3.5.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -53,7 +53,7 @@ jobs:
 
       - name: Extract Image Metadata
         id: metadata
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v5 #v5.8.0
         with:
           images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
           flavor: |
@@ -65,7 +65,7 @@ jobs:
             type=raw,value=${{ env.IMAGE_NAME }}-{{tag}}-{{date 'YYYYMMDD'}}-{{sha}},priority=32,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
 
       - name: Build and Push Container Image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v6 #v6.18.0
         with:
           context: .
           file: ./docker/Dockerfile

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v4 #v4.4.0
         with:
           node-version: 20
 


### PR DESCRIPTION
A few of the actions are missing the convention of version commenting, ie #vX.Y.Z.

This leads to renovate not showing versions and only shas for those, as seen in https://github.com/diggsweden/wallet-verifier-test-web/pull/26 for example.

Dont worry to much about the shas and versions being 100% correct in symmetry to each other for this, renovate will always autocorrect this in further updates. 

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
