### PR TITLE
fix: prepend app_base_url to same device redirect

### DIFF
--- a/server/api/verifier-status/[id].ts
+++ b/server/api/verifier-status/[id].ts
@@ -10,6 +10,10 @@ export default defineEventHandler(async (event) => {
     process.env.HOST_API ||
     config.public.hostApi ||
     "http://eudi-verifier-backend:8080";
+  const baseUrl =
+    process.env.PUBLIC_BASE_URL ||
+    process.env.NUXT_PUBLIC_BASE_URL ||
+    "";
 
   if (responseCode) {
     const storage = useStorage("memory");
@@ -18,7 +22,7 @@ export default defineEventHandler(async (event) => {
     if (!transactionData) {
       return sendRedirect(
         event,
-        "/verify?error=Invalid%20verification%20link",
+        `${baseUrl}/verify?error=Invalid%20verification%20link`,
         302,
       );
     }
@@ -38,12 +42,24 @@ export default defineEventHandler(async (event) => {
       if (response && response.vp_token) {
         const verifiedData = parseVpToken(response.vp_token);
         const data = encodeURIComponent(JSON.stringify(verifiedData));
-        return sendRedirect(event, `/verify?success=true&data=${data}`, 302);
+        return sendRedirect(
+          event,
+          `${baseUrl}/verify?success=true&data=${data}`,
+          302,
+        );
       }
 
-      return sendRedirect(event, "/verify?error=Verification%20pending", 302);
+      return sendRedirect(
+        event,
+        `${baseUrl}/verify?error=Verification%20pending`,
+        302,
+      );
     } catch (error) {
-      return sendRedirect(event, "/verify?error=Verification%20failed", 302);
+      return sendRedirect(
+        event,
+        `${baseUrl}/verify?error=Verification%20failed`,
+        302,
+      );
     }
   }
 

--- a/server/api/verifier-status/[id].ts
+++ b/server/api/verifier-status/[id].ts
@@ -11,9 +11,7 @@ export default defineEventHandler(async (event) => {
     config.public.hostApi ||
     "http://eudi-verifier-backend:8080";
   const baseUrl =
-    process.env.PUBLIC_BASE_URL ||
-    process.env.NUXT_PUBLIC_BASE_URL ||
-    "";
+    process.env.PUBLIC_BASE_URL || process.env.NUXT_PUBLIC_BASE_URL || "";
 
   if (responseCode) {
     const storage = useStorage("memory");


### PR DESCRIPTION
# Pull Request Description

This fixes the same device redirect so users end up on the success/error page after approving a presentation in their wallet.

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
