### PR TITLE
Bugfix/backport revert nuxt v4

### DIFF
--- a/development/until_failure.sh
+++ b/development/until_failure.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+#
+# This scripts provides a way to run the same command repeateadly until it
+# fails. It can be used to check the stability of test suites or individual
+# tests. By default the given command is repeated 100 times.
+#
+#	# Rerun 'npm run test:once' until it fails or maximum 100 times
+# 	./development/until_failure.sh 'npm run test:once'
+#
+#	# Same as above, but stop after ten iterations
+# 	./development/until_failure.sh 'npm run test:once' 10
+#
+readonly command="$1"
+readonly max="${2:-100}"
+
+echo "Running command '$command' $max times or until failure"
+for n in $(seq 1 "$max"); do
+  echo "Attempt $n of $max"
+
+  if $command; then
+    echo 'Success!'
+  else
+    echo "Failed on attempt $n!"
+    exit 1
+  fi
+done
+echo "Tried $max times without failure."

--- a/package-lock.json
+++ b/package-lock.json
@@ -2392,9 +2392,9 @@
       }
     },
     "node_modules/@nuxt/schema": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@nuxt/schema/-/schema-4.1.1.tgz",
-      "integrity": "sha512-s4ELQEw6er4kop4e9HkTZ2ByVEvOGic9YJmesr2QI3O+q01CLSZE6aepbRLsq1Hz6bbfq/UrFw8MLuHs7l03aA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@nuxt/schema/-/schema-4.1.0.tgz",
+      "integrity": "sha512-LvcsO7XIYD+rqjxsjaBHUyOgN2Vw8MCF4rvuF09P/UqEogbck94zrwzSTYk6FVU7K6eQO/egvefanGMj/nPkMg==",
       "license": "MIT",
       "dependencies": {
         "@vue/shared": "^3.5.20",
@@ -2526,12 +2526,12 @@
       }
     },
     "node_modules/@nuxt/vite-builder": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@nuxt/vite-builder/-/vite-builder-4.1.1.tgz",
-      "integrity": "sha512-hRIHu9a1x2HFFSXQt3+eG4s8GP1QhuzjiCmd/sciC55NISc0oP69tTmOmFOp3L8G2BapSZ/O1CZEnO/XoAqZkA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@nuxt/vite-builder/-/vite-builder-4.1.0.tgz",
+      "integrity": "sha512-eya04QZ+j6n+Ru3zyYDGrXGKuBdgBro2FrDiQl5faKK9fK4dqNYuBGeYNKmBHNZg6fOnUUEaGrZmK/EfrLBmcw==",
       "license": "MIT",
       "dependencies": {
-        "@nuxt/kit": "4.1.1",
+        "@nuxt/kit": "4.1.0",
         "@rollup/plugin-replace": "^6.0.2",
         "@vitejs/plugin-vue": "^6.0.1",
         "@vitejs/plugin-vue-jsx": "^5.1.1",
@@ -2569,9 +2569,9 @@
       }
     },
     "node_modules/@nuxt/vite-builder/node_modules/@nuxt/kit": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-4.1.1.tgz",
-      "integrity": "sha512-2MGfOXtbcxdkbUNZDjyEv4xmokicZhTrQBMrmNJQztrePfpKOVBe8AiGf/BfbHelXMKio5PgktiRoiEIyIsX4g==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-4.1.0.tgz",
+      "integrity": "sha512-QY6wgano7szNP5hLUKNeZTLdx009F2n+a8L9M4Wzk1jhubvENc81jLWHAnaJOogRpqMeEqZcjHRfqTx+J1/lfQ==",
       "license": "MIT",
       "dependencies": {
         "c12": "^3.2.0",
@@ -10016,18 +10016,18 @@
       }
     },
     "node_modules/nuxt": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/nuxt/-/nuxt-4.1.1.tgz",
-      "integrity": "sha512-xLDbWgz3ggAfUjcbmTzmLLPWOEB61thnjnqyasZlYyh/Ty2EDT1qvOiM9HT+9ycBxElI2DmyYewY8WOPRxWMiQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/nuxt/-/nuxt-4.1.0.tgz",
+      "integrity": "sha512-bnHWcztOrxjBMcoiqO51cVR0kzycohTazrdEVgL2I6U5gCX3R63XWP+PQ2itO/DCdZPP5i9ZF9HsJGXYbc5w/g==",
       "license": "MIT",
       "dependencies": {
         "@nuxt/cli": "^3.28.0",
         "@nuxt/devalue": "^2.0.2",
         "@nuxt/devtools": "^2.6.3",
-        "@nuxt/kit": "4.1.1",
-        "@nuxt/schema": "4.1.1",
+        "@nuxt/kit": "4.1.0",
+        "@nuxt/schema": "4.1.0",
         "@nuxt/telemetry": "^2.6.6",
-        "@nuxt/vite-builder": "4.1.1",
+        "@nuxt/vite-builder": "4.1.0",
         "@unhead/vue": "^2.0.14",
         "@vue/shared": "^3.5.20",
         "c12": "^3.2.0",
@@ -10070,6 +10070,7 @@
         "scule": "^1.3.0",
         "semver": "^7.7.2",
         "std-env": "^3.9.0",
+        "strip-literal": "^3.0.0",
         "tinyglobby": "0.2.14",
         "ufo": "^1.6.1",
         "ultrahtml": "^1.6.0",
@@ -10121,9 +10122,9 @@
       }
     },
     "node_modules/nuxt/node_modules/@nuxt/kit": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-4.1.1.tgz",
-      "integrity": "sha512-2MGfOXtbcxdkbUNZDjyEv4xmokicZhTrQBMrmNJQztrePfpKOVBe8AiGf/BfbHelXMKio5PgktiRoiEIyIsX4g==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-4.1.0.tgz",
+      "integrity": "sha512-QY6wgano7szNP5hLUKNeZTLdx009F2n+a8L9M4Wzk1jhubvENc81jLWHAnaJOogRpqMeEqZcjHRfqTx+J1/lfQ==",
       "license": "MIT",
       "dependencies": {
         "c12": "^3.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@vue/test-utils": "2.4.6",
         "autoprefixer": "10.4.21",
         "happy-dom": "18.0.1",
-        "nuxt-qrcode": "0.4.7",
+        "nuxt-qrcode": "0.4.6",
         "postcss": "8.5.6",
         "tailwindcss": "4.1.13",
         "typescript": "5.9.2",
@@ -5207,13 +5207,13 @@
       }
     },
     "node_modules/@vue/compiler-core": {
-      "version": "3.5.21",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.21.tgz",
-      "integrity": "sha512-8i+LZ0vf6ZgII5Z9XmUvrCyEzocvWT+TeR2VBUVlzIH6Tyv57E20mPZ1bCS+tbejgUgmjrEh7q/0F0bibskAmw==",
+      "version": "3.5.20",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.20.tgz",
+      "integrity": "sha512-8TWXUyiqFd3GmP4JTX9hbiTFRwYHgVL/vr3cqhr4YQ258+9FADwvj7golk2sWNGHR67QgmCZ8gz80nQcMokhwg==",
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.28.3",
-        "@vue/shared": "3.5.21",
+        "@vue/shared": "3.5.20",
         "entities": "^4.5.0",
         "estree-walker": "^2.0.2",
         "source-map-js": "^1.2.1"
@@ -5226,28 +5226,28 @@
       "license": "MIT"
     },
     "node_modules/@vue/compiler-dom": {
-      "version": "3.5.21",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.21.tgz",
-      "integrity": "sha512-jNtbu/u97wiyEBJlJ9kmdw7tAr5Vy0Aj5CgQmo+6pxWNQhXZDPsRr1UWPN4v3Zf82s2H3kF51IbzZ4jMWAgPlQ==",
+      "version": "3.5.20",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.20.tgz",
+      "integrity": "sha512-whB44M59XKjqUEYOMPYU0ijUV0G+4fdrHVKDe32abNdX/kJe1NUEMqsi4cwzXa9kyM9w5S8WqFsrfo1ogtBZGQ==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-core": "3.5.21",
-        "@vue/shared": "3.5.21"
+        "@vue/compiler-core": "3.5.20",
+        "@vue/shared": "3.5.20"
       }
     },
     "node_modules/@vue/compiler-sfc": {
-      "version": "3.5.21",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.21.tgz",
-      "integrity": "sha512-SXlyk6I5eUGBd2v8Ie7tF6ADHE9kCR6mBEuPyH1nUZ0h6Xx6nZI29i12sJKQmzbDyr2tUHMhhTt51Z6blbkTTQ==",
+      "version": "3.5.20",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.20.tgz",
+      "integrity": "sha512-SFcxapQc0/feWiSBfkGsa1v4DOrnMAQSYuvDMpEaxbpH5dKbnEM5KobSNSgU+1MbHCl+9ftm7oQWxvwDB6iBfw==",
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.28.3",
-        "@vue/compiler-core": "3.5.21",
-        "@vue/compiler-dom": "3.5.21",
-        "@vue/compiler-ssr": "3.5.21",
-        "@vue/shared": "3.5.21",
+        "@vue/compiler-core": "3.5.20",
+        "@vue/compiler-dom": "3.5.20",
+        "@vue/compiler-ssr": "3.5.20",
+        "@vue/shared": "3.5.20",
         "estree-walker": "^2.0.2",
-        "magic-string": "^0.30.18",
+        "magic-string": "^0.30.17",
         "postcss": "^8.5.6",
         "source-map-js": "^1.2.1"
       }
@@ -5259,13 +5259,13 @@
       "license": "MIT"
     },
     "node_modules/@vue/compiler-ssr": {
-      "version": "3.5.21",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.21.tgz",
-      "integrity": "sha512-vKQ5olH5edFZdf5ZrlEgSO1j1DMA4u23TVK5XR1uMhvwnYvVdDF0nHXJUblL/GvzlShQbjhZZ2uvYmDlAbgo9w==",
+      "version": "3.5.20",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.20.tgz",
+      "integrity": "sha512-RSl5XAMc5YFUXpDQi+UQDdVjH9FnEpLDHIALg5J0ITHxkEzJ8uQLlo7CIbjPYqmZtt6w0TsIPbo1izYXwDG7JA==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-dom": "3.5.21",
-        "@vue/shared": "3.5.21"
+        "@vue/compiler-dom": "3.5.20",
+        "@vue/shared": "3.5.20"
       }
     },
     "node_modules/@vue/compiler-vue2": {
@@ -5350,53 +5350,53 @@
       }
     },
     "node_modules/@vue/reactivity": {
-      "version": "3.5.21",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.21.tgz",
-      "integrity": "sha512-3ah7sa+Cwr9iiYEERt9JfZKPw4A2UlbY8RbbnH2mGCE8NwHkhmlZt2VsH0oDA3P08X3jJd29ohBDtX+TbD9AsA==",
+      "version": "3.5.20",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.20.tgz",
+      "integrity": "sha512-hS8l8x4cl1fmZpSQX/NXlqWKARqEsNmfkwOIYqtR2F616NGfsLUm0G6FQBK6uDKUCVyi1YOL8Xmt/RkZcd/jYQ==",
       "license": "MIT",
       "dependencies": {
-        "@vue/shared": "3.5.21"
+        "@vue/shared": "3.5.20"
       }
     },
     "node_modules/@vue/runtime-core": {
-      "version": "3.5.21",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.21.tgz",
-      "integrity": "sha512-+DplQlRS4MXfIf9gfD1BOJpk5RSyGgGXD/R+cumhe8jdjUcq/qlxDawQlSI8hCKupBlvM+3eS1se5xW+SuNAwA==",
+      "version": "3.5.20",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.20.tgz",
+      "integrity": "sha512-vyQRiH5uSZlOa+4I/t4Qw/SsD/gbth0SW2J7oMeVlMFMAmsG1rwDD6ok0VMmjXY3eI0iHNSSOBilEDW98PLRKw==",
       "license": "MIT",
       "dependencies": {
-        "@vue/reactivity": "3.5.21",
-        "@vue/shared": "3.5.21"
+        "@vue/reactivity": "3.5.20",
+        "@vue/shared": "3.5.20"
       }
     },
     "node_modules/@vue/runtime-dom": {
-      "version": "3.5.21",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.21.tgz",
-      "integrity": "sha512-3M2DZsOFwM5qI15wrMmNF5RJe1+ARijt2HM3TbzBbPSuBHOQpoidE+Pa+XEaVN+czbHf81ETRoG1ltztP2em8w==",
+      "version": "3.5.20",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.20.tgz",
+      "integrity": "sha512-KBHzPld/Djw3im0CQ7tGCpgRedryIn4CcAl047EhFTCCPT2xFf4e8j6WeKLgEEoqPSl9TYqShc3Q6tpWpz/Xgw==",
       "license": "MIT",
       "dependencies": {
-        "@vue/reactivity": "3.5.21",
-        "@vue/runtime-core": "3.5.21",
-        "@vue/shared": "3.5.21",
+        "@vue/reactivity": "3.5.20",
+        "@vue/runtime-core": "3.5.20",
+        "@vue/shared": "3.5.20",
         "csstype": "^3.1.3"
       }
     },
     "node_modules/@vue/server-renderer": {
-      "version": "3.5.21",
-      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.21.tgz",
-      "integrity": "sha512-qr8AqgD3DJPJcGvLcJKQo2tAc8OnXRcfxhOJCPF+fcfn5bBGz7VCcO7t+qETOPxpWK1mgysXvVT/j+xWaHeMWA==",
+      "version": "3.5.20",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.20.tgz",
+      "integrity": "sha512-HthAS0lZJDH21HFJBVNTtx+ULcIbJQRpjSVomVjfyPkFSpCwvsPTA+jIzOaUm3Hrqx36ozBHePztQFg6pj5aKg==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-ssr": "3.5.21",
-        "@vue/shared": "3.5.21"
+        "@vue/compiler-ssr": "3.5.20",
+        "@vue/shared": "3.5.20"
       },
       "peerDependencies": {
-        "vue": "3.5.21"
+        "vue": "3.5.20"
       }
     },
     "node_modules/@vue/shared": {
-      "version": "3.5.21",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.21.tgz",
-      "integrity": "sha512-+2k1EQpnYuVuu3N7atWyG3/xoFWIVJZq4Mz8XNOdScFI0etES75fbny/oU4lKWk/577P1zmg0ioYvpGEDZ3DLw==",
+      "version": "3.5.20",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.20.tgz",
+      "integrity": "sha512-SoRGP596KU/ig6TfgkCMbXkr4YJ91n/QSdMuqeP5r3hVIYA3CPHUBCc7Skak0EAKV+5lL4KyIh61VA/pK1CIAA==",
       "license": "MIT"
     },
     "node_modules/@vue/test-utils": {
@@ -10107,9 +10107,9 @@
       }
     },
     "node_modules/nuxt-qrcode": {
-      "version": "0.4.7",
-      "resolved": "https://registry.npmjs.org/nuxt-qrcode/-/nuxt-qrcode-0.4.7.tgz",
-      "integrity": "sha512-o9ER4aFok+tNSkUhXPkZiKOmJ6WzVJxhUDABRIjB6WGb5cugpeaUERpYXnJBDQnFQICLhsQy10AAMyJncYeVWA==",
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/nuxt-qrcode/-/nuxt-qrcode-0.4.6.tgz",
+      "integrity": "sha512-O3oBQLVKFVkwUr8Ifg4Z3G6hkpOYyT+hhQen1+tNnYmacYwyevUbqFMNNNeEcGkMJsBgwiSLzCv8ZjHPFNxKiA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13620,16 +13620,16 @@
       "license": "MIT"
     },
     "node_modules/vue": {
-      "version": "3.5.21",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.21.tgz",
-      "integrity": "sha512-xxf9rum9KtOdwdRkiApWL+9hZEMWE90FHh8yS1+KJAiWYh+iGWV1FquPjoO9VUHQ+VIhsCXNNyZ5Sf4++RVZBA==",
+      "version": "3.5.20",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.20.tgz",
+      "integrity": "sha512-2sBz0x/wis5TkF1XZ2vH25zWq3G1bFEPOfkBcx2ikowmphoQsPH6X0V3mmPCXA2K1N/XGTnifVyDQP4GfDDeQw==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-dom": "3.5.21",
-        "@vue/compiler-sfc": "3.5.21",
-        "@vue/runtime-dom": "3.5.21",
-        "@vue/server-renderer": "3.5.21",
-        "@vue/shared": "3.5.21"
+        "@vue/compiler-dom": "3.5.20",
+        "@vue/compiler-sfc": "3.5.20",
+        "@vue/runtime-dom": "3.5.20",
+        "@vue/server-renderer": "3.5.20",
+        "@vue/shared": "3.5.20"
       },
       "peerDependencies": {
         "typescript": "*"

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@heroicons/vue": "^2.2.0",
         "jimp": "^1.6.0",
         "jose": "^6.0.11",
-        "nuxt": "^4.0.0",
+        "nuxt": "^3.17.5",
         "qrcode-reader": "^1.0.4",
         "vue": "^3.5.16",
         "vue-router": "^4.5.1"
@@ -29,7 +29,7 @@
         "tailwindcss": "4.1.13",
         "typescript": "5.9.2",
         "vitest": "3.2.4",
-        "vue-tsc": "3.0.6"
+        "vue-tsc": "2.2.12"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -2392,12 +2392,12 @@
       }
     },
     "node_modules/@nuxt/schema": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@nuxt/schema/-/schema-4.1.0.tgz",
-      "integrity": "sha512-LvcsO7XIYD+rqjxsjaBHUyOgN2Vw8MCF4rvuF09P/UqEogbck94zrwzSTYk6FVU7K6eQO/egvefanGMj/nPkMg==",
+      "version": "3.18.1",
+      "resolved": "https://registry.npmjs.org/@nuxt/schema/-/schema-3.18.1.tgz",
+      "integrity": "sha512-0237FcmSklop7qZUzldPn01wF6R1subQpkhgJKciONV3n4pu4DDYObTLzG9R3zGvXYRNfeMX38ktxVY2TMQ3AQ==",
       "license": "MIT",
       "dependencies": {
-        "@vue/shared": "^3.5.20",
+        "@vue/shared": "^3.5.18",
         "consola": "^3.4.2",
         "defu": "^6.1.4",
         "pathe": "^2.0.3",
@@ -2526,39 +2526,42 @@
       }
     },
     "node_modules/@nuxt/vite-builder": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@nuxt/vite-builder/-/vite-builder-4.1.0.tgz",
-      "integrity": "sha512-eya04QZ+j6n+Ru3zyYDGrXGKuBdgBro2FrDiQl5faKK9fK4dqNYuBGeYNKmBHNZg6fOnUUEaGrZmK/EfrLBmcw==",
+      "version": "3.18.1",
+      "resolved": "https://registry.npmjs.org/@nuxt/vite-builder/-/vite-builder-3.18.1.tgz",
+      "integrity": "sha512-+FnObSM3eYdMTPIPuKShvIGn5wEU9uPyPWF4v4pHS6Eg2usuz5WDugibSEWw4shSC0tsPla19DxwA4KSCxluWg==",
       "license": "MIT",
       "dependencies": {
-        "@nuxt/kit": "4.1.0",
+        "@nuxt/kit": "3.18.1",
         "@rollup/plugin-replace": "^6.0.2",
         "@vitejs/plugin-vue": "^6.0.1",
-        "@vitejs/plugin-vue-jsx": "^5.1.1",
+        "@vitejs/plugin-vue-jsx": "^5.0.1",
         "autoprefixer": "^10.4.21",
         "consola": "^3.4.2",
-        "cssnano": "^7.1.1",
+        "cssnano": "^7.1.0",
         "defu": "^6.1.4",
-        "esbuild": "^0.25.9",
+        "esbuild": "^0.25.8",
         "escape-string-regexp": "^5.0.0",
         "exsolve": "^1.0.7",
+        "externality": "^1.0.2",
         "get-port-please": "^3.2.0",
         "h3": "^1.15.4",
         "jiti": "^2.5.1",
         "knitwork": "^1.2.0",
-        "magic-string": "^0.30.18",
-        "mlly": "^1.8.0",
+        "magic-string": "^0.30.17",
+        "mlly": "^1.7.4",
         "mocked-exports": "^0.1.1",
+        "ohash": "^2.0.11",
         "pathe": "^2.0.3",
-        "pkg-types": "^2.3.0",
+        "perfect-debounce": "^1.0.0",
+        "pkg-types": "^2.2.0",
         "postcss": "^8.5.6",
         "rollup-plugin-visualizer": "^6.0.3",
         "std-env": "^3.9.0",
         "ufo": "^1.6.1",
         "unenv": "^2.0.0-rc.19",
-        "vite": "^7.1.4",
+        "vite": "^7.0.6",
         "vite-node": "^3.2.4",
-        "vite-plugin-checker": "^0.10.3",
+        "vite-plugin-checker": "^0.10.2",
         "vue-bundle-renderer": "^2.1.2"
       },
       "engines": {
@@ -2566,39 +2569,6 @@
       },
       "peerDependencies": {
         "vue": "^3.3.4"
-      }
-    },
-    "node_modules/@nuxt/vite-builder/node_modules/@nuxt/kit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-4.1.0.tgz",
-      "integrity": "sha512-QY6wgano7szNP5hLUKNeZTLdx009F2n+a8L9M4Wzk1jhubvENc81jLWHAnaJOogRpqMeEqZcjHRfqTx+J1/lfQ==",
-      "license": "MIT",
-      "dependencies": {
-        "c12": "^3.2.0",
-        "consola": "^3.4.2",
-        "defu": "^6.1.4",
-        "destr": "^2.0.5",
-        "errx": "^0.1.0",
-        "exsolve": "^1.0.7",
-        "ignore": "^7.0.5",
-        "jiti": "^2.5.1",
-        "klona": "^2.0.6",
-        "mlly": "^1.8.0",
-        "ohash": "^2.0.11",
-        "pathe": "^2.0.3",
-        "pkg-types": "^2.3.0",
-        "rc9": "^2.1.2",
-        "scule": "^1.3.0",
-        "semver": "^7.7.2",
-        "std-env": "^3.9.0",
-        "tinyglobby": "^0.2.14",
-        "ufo": "^1.6.1",
-        "unctx": "^2.4.1",
-        "unimport": "^5.2.0",
-        "untyped": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=18.12.0"
       }
     },
     "node_modules/@nuxtjs/tailwindcss": {
@@ -2658,9 +2628,9 @@
       "license": "MIT"
     },
     "node_modules/@oxc-minify/binding-android-arm64": {
-      "version": "0.86.0",
-      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-android-arm64/-/binding-android-arm64-0.86.0.tgz",
-      "integrity": "sha512-jOgbDgp6A1ax9sxHPRHBxUpxIzp2VTgbZ/6HPKIVUJ7IQqKVsELKFXIOEbCDlb1rUhZZtGf53MFypXf72kR5eQ==",
+      "version": "0.80.0",
+      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-android-arm64/-/binding-android-arm64-0.80.0.tgz",
+      "integrity": "sha512-OLelUqrLkSJwNyjLZHgpKy9n0+zHQiMX8A0GFovJIwhgfPxjT/mt2JMnGkSoDlTnf9cw6nvALFzCsJZLTyl8gg==",
       "cpu": [
         "arm64"
       ],
@@ -2674,9 +2644,9 @@
       }
     },
     "node_modules/@oxc-minify/binding-darwin-arm64": {
-      "version": "0.86.0",
-      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-darwin-arm64/-/binding-darwin-arm64-0.86.0.tgz",
-      "integrity": "sha512-LQkjIHhIzxVYnxfC2QV7MMe4hgqIbwK07j+zzEsNWWfdmWABw11Aa6FP0uIvERmoxstzsDT77F8c/+xhxswKiw==",
+      "version": "0.80.0",
+      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-darwin-arm64/-/binding-darwin-arm64-0.80.0.tgz",
+      "integrity": "sha512-7vJjhKHGfFVit3PCerbnrXQI0XgmmgV5HTNxlNsvxcmjPRIoYVkuwwRkiBsxO4RiBwvRRkAFPop3fY/gpuflJA==",
       "cpu": [
         "arm64"
       ],
@@ -2690,9 +2660,9 @@
       }
     },
     "node_modules/@oxc-minify/binding-darwin-x64": {
-      "version": "0.86.0",
-      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-darwin-x64/-/binding-darwin-x64-0.86.0.tgz",
-      "integrity": "sha512-AuLkeXIvJ535qOhFzZfHBkcEZA59SN1vKUblW2oN+6ClZfIMru0I2wr0cCHA9QDxIVDkI7swDu29qcn2AqKdrg==",
+      "version": "0.80.0",
+      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-darwin-x64/-/binding-darwin-x64-0.80.0.tgz",
+      "integrity": "sha512-jKnRVtwVhspd8djNSQMICOZe6gQBwXTcfHylZ2Azw4ZXvqTyxDqgcEGgx0WyaqvUTLHdX42nJCHRHHy6MOVPOg==",
       "cpu": [
         "x64"
       ],
@@ -2706,9 +2676,9 @@
       }
     },
     "node_modules/@oxc-minify/binding-freebsd-x64": {
-      "version": "0.86.0",
-      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-freebsd-x64/-/binding-freebsd-x64-0.86.0.tgz",
-      "integrity": "sha512-UcXLcM8+iHW1EL+peHHV1HDBFUVdoxFMJC7HBc2U83q9oiF/K73TnAEgW/xteR+IvbV/9HD+cQsH+DX6oBXoQg==",
+      "version": "0.80.0",
+      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-freebsd-x64/-/binding-freebsd-x64-0.80.0.tgz",
+      "integrity": "sha512-iO7KjJsFpDtG5w8T6twTxLsvffn8PsjBbBUwjzVPfSD4YlsHDd0GjIVYcP+1TXzLRlV4zWmd67SOBnNyreSGBg==",
       "cpu": [
         "x64"
       ],
@@ -2722,9 +2692,9 @@
       }
     },
     "node_modules/@oxc-minify/binding-linux-arm-gnueabihf": {
-      "version": "0.86.0",
-      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.86.0.tgz",
-      "integrity": "sha512-UtSplQY10Idp//cLS5i2rFaunS71padZFavHLHygNAxJBt+37DPKDl/4kddpV6Kv2Mr6bhw2KpXGAVs0C3dIOw==",
+      "version": "0.80.0",
+      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.80.0.tgz",
+      "integrity": "sha512-uwBdietv8USofOUAOcxyta14VbcJiFizQUMuCB9sLkK+Nh/CV5U2SVjsph5HlARGVu8V2DF+FXROD6sTl9DLiA==",
       "cpu": [
         "arm"
       ],
@@ -2738,9 +2708,9 @@
       }
     },
     "node_modules/@oxc-minify/binding-linux-arm-musleabihf": {
-      "version": "0.86.0",
-      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.86.0.tgz",
-      "integrity": "sha512-P5efCOl9QiwqqJHrw1Q+4ssexvOz+MAmgTmBorbdEM3WJdIHR1CWGDj4GqcvKBlwpBqt4XilOuoN0QD8dfl85A==",
+      "version": "0.80.0",
+      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.80.0.tgz",
+      "integrity": "sha512-6QAWCjH9in7JvpHRxX8M1IEkf+Eot82Q02xmikcACyJag26196XdVq2T9ITcwFtliozYxYP6yPQ5OzLoeeqdmg==",
       "cpu": [
         "arm"
       ],
@@ -2754,9 +2724,9 @@
       }
     },
     "node_modules/@oxc-minify/binding-linux-arm64-gnu": {
-      "version": "0.86.0",
-      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.86.0.tgz",
-      "integrity": "sha512-hwHahfs//g9iZLQmKldjQPmnpzq76eyHvfkmdnXXmPtwTHnwXL1hPlNbTIqakUirAsroBeQwXqzHm3I040R+mg==",
+      "version": "0.80.0",
+      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.80.0.tgz",
+      "integrity": "sha512-1PxO983GNFSyvY6lpYpH3uA/5NHuei7CHExe+NSB+ZgQ1T/iBMjXxRml1Woedvi8odSSpZlivZxBiEojIcnfqw==",
       "cpu": [
         "arm64"
       ],
@@ -2770,9 +2740,9 @@
       }
     },
     "node_modules/@oxc-minify/binding-linux-arm64-musl": {
-      "version": "0.86.0",
-      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.86.0.tgz",
-      "integrity": "sha512-S2dL24nxWqDCwrq48xlZBvhSIBcEWOu3aDOiaccP4q73PiTLrf6rm1M11J7vQNSRiH6ao9UKr7ZMsepCZcOyfA==",
+      "version": "0.80.0",
+      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.80.0.tgz",
+      "integrity": "sha512-D2j5L9Z4OO42We0Lo2GkXT/AaNikzZJ8KZ9V2VVwu7kofI4RsO8kSu8ydWlqRlRdiAprmUpRZU/pNW0ZA7A68w==",
       "cpu": [
         "arm64"
       ],
@@ -2786,9 +2756,9 @@
       }
     },
     "node_modules/@oxc-minify/binding-linux-riscv64-gnu": {
-      "version": "0.86.0",
-      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.86.0.tgz",
-      "integrity": "sha512-itZ24A1a5NOw0ibbt6EYOHdBojfV4vbiC209d06Dwv5WLXtntHCjc8P4yfrCsC22uDmMPNkVa+UL+OM4mkUrwg==",
+      "version": "0.80.0",
+      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.80.0.tgz",
+      "integrity": "sha512-2AztlLcio5OGil70wjRLbxbjlfS1yCTzO+CYan49vfUOCXpwSWwwLD2WDzFokhEXAzf8epbbu7pruYk8qorRRg==",
       "cpu": [
         "riscv64"
       ],
@@ -2802,9 +2772,9 @@
       }
     },
     "node_modules/@oxc-minify/binding-linux-s390x-gnu": {
-      "version": "0.86.0",
-      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.86.0.tgz",
-      "integrity": "sha512-/nJAwS/uit19qXNpaOybf7GYJI7modbXYVZ8q1pIFdxs6HkhZLxS1ZvcIzY3W75+37u+uKeZ4MbygawAN8kQpQ==",
+      "version": "0.80.0",
+      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.80.0.tgz",
+      "integrity": "sha512-5GMKARe4gYHhA7utM8qOgv3WM7KAXGZGG3Jhvk4UQSRBp0v6PKFmHmz8Q93+Ep8w1m4NqRL30Zk9CZHMH/qi5g==",
       "cpu": [
         "s390x"
       ],
@@ -2818,9 +2788,9 @@
       }
     },
     "node_modules/@oxc-minify/binding-linux-x64-gnu": {
-      "version": "0.86.0",
-      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.86.0.tgz",
-      "integrity": "sha512-3qnWZB2cOj5Em/uEJqJ1qP/8lxtoi/Rf1U8fmdLzPW5zIaiTRUr/LklB4aJ+Vc/GU5g3HX5nFPQG3ZnEV3Ktzg==",
+      "version": "0.80.0",
+      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.80.0.tgz",
+      "integrity": "sha512-iw45N+OVnPioRQXLHfrsqEcTpydcGSHLphilS3aSpc4uVKnOqCybskKnbEnxsIJqHWbzDZeJgzuRuQa7EhNcqg==",
       "cpu": [
         "x64"
       ],
@@ -2834,9 +2804,9 @@
       }
     },
     "node_modules/@oxc-minify/binding-linux-x64-musl": {
-      "version": "0.86.0",
-      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-x64-musl/-/binding-linux-x64-musl-0.86.0.tgz",
-      "integrity": "sha512-+ZqYG8IQSRq9dR2djrnyzGHlmwGRKdueVjHYbEOwngb/4h/+FxAOaNUbsoUsCthAfXTrZHVXiQMTKJ32r7j2Bg==",
+      "version": "0.80.0",
+      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-x64-musl/-/binding-linux-x64-musl-0.80.0.tgz",
+      "integrity": "sha512-4+dhYznVM+L9Jh855JBbqVyDjwi3p8rpL7RfgN+Ee1oQMaZl2ZPy2shS1Kj56Xr5haTTVGdRKcIqTU8SuF37UQ==",
       "cpu": [
         "x64"
       ],
@@ -2850,25 +2820,25 @@
       }
     },
     "node_modules/@oxc-minify/binding-wasm32-wasi": {
-      "version": "0.86.0",
-      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-wasm32-wasi/-/binding-wasm32-wasi-0.86.0.tgz",
-      "integrity": "sha512-ixeSZW7jzd3g9fh8MoR9AzGLQxMCo//Q2mVpO2S/4NmcPtMaJEog85KzHULgUvbs70RqxTHEUqtVgpnc/5lMWA==",
+      "version": "0.80.0",
+      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-wasm32-wasi/-/binding-wasm32-wasi-0.80.0.tgz",
+      "integrity": "sha512-flADFeNwC1/XsBBsESAigsJZyONEBloQO86Z38ZNzLSuMmpGRdwB9gUwlPCQgDRND/aB+tvR29hKTSuQoS3yrg==",
       "cpu": [
         "wasm32"
       ],
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@napi-rs/wasm-runtime": "^1.0.3"
+        "@napi-rs/wasm-runtime": "^1.0.1"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@oxc-minify/binding-win32-arm64-msvc": {
-      "version": "0.86.0",
-      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.86.0.tgz",
-      "integrity": "sha512-cN309CnFVG8jeSRd+lQGnoMpZAVmz4bzH4fgqJM0NsMXVnFPGFceG/XiToLoBA1FigGQvkV0PJ7MQKWxBHPoUA==",
+      "version": "0.80.0",
+      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.80.0.tgz",
+      "integrity": "sha512-wFjaEHzczIG9GqnL4c4C3PoThzf1640weQ1eEjh96TnHVdZmiNT5lpGoziJhO/c+g9+6sNrTdz9sqsiVgKwdOg==",
       "cpu": [
         "arm64"
       ],
@@ -2882,9 +2852,9 @@
       }
     },
     "node_modules/@oxc-minify/binding-win32-x64-msvc": {
-      "version": "0.86.0",
-      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.86.0.tgz",
-      "integrity": "sha512-YAqCKtZ9KKhSW73d/Oa9Uut0myYnCEUL2D0buMjJ4p0PuK1PQsMCJsmX4ku0PgK31snanZneRwtEjjNFYNdX2A==",
+      "version": "0.80.0",
+      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.80.0.tgz",
+      "integrity": "sha512-PjMi5B3MvOmfZk5LTie6g3RHhhujFwgR4VbCrWUNNwSzdxzy3dULPT4PWGVbpTas/QLJzXs/CXlQfnaMeJZHKQ==",
       "cpu": [
         "x64"
       ],
@@ -2898,9 +2868,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-android-arm64": {
-      "version": "0.86.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.86.0.tgz",
-      "integrity": "sha512-BfNFEWpRo4gqLHKvRuQmhbPGeJqB1Ka/hsPhKf1imAojwUcf/Dr/yRkZBuEi2yc1LWBjApKYJEqpsBUmtqSY1Q==",
+      "version": "0.80.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.80.0.tgz",
+      "integrity": "sha512-H0S4QTRFhct1uO1ZOnzGQAoHSJVHCyZa+oivovHkbqA0z271ppRkXmJuLfjW+9CBW0577JNAhjTflKUDpCO4lg==",
       "cpu": [
         "arm64"
       ],
@@ -2914,9 +2884,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-darwin-arm64": {
-      "version": "0.86.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.86.0.tgz",
-      "integrity": "sha512-gRSnEHcyNEfLdNj6v8XKcuHUaZnRpH2lOZFztuGEi23ENydPOQVEtiZYexuHOTeaLGgzw+93TgB4n/YkjYodug==",
+      "version": "0.80.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.80.0.tgz",
+      "integrity": "sha512-cVGI6NeGs1u1Ev8yO7I+zXPQuduCwwhYXd/K64uygx+OFp7fC7zSIlkGpoxFRUuSxqyipC813foAfUOwM1Y0PA==",
       "cpu": [
         "arm64"
       ],
@@ -2930,9 +2900,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-darwin-x64": {
-      "version": "0.86.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.86.0.tgz",
-      "integrity": "sha512-6mdymm8i+VpLTJP19D3PSFumMmAyfhhhIRWcRHsc0bL7CSZjCWbvRb00ActKrGKWtsol/A/KKgqglJwpvjlzOA==",
+      "version": "0.80.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.80.0.tgz",
+      "integrity": "sha512-h7wRo10ywI2vLz9VljFeIaUh9u7l2l3kvF6FAteY3cPqbCA6JYUZGJaykhMqTxJoG6wrzf35sMA2ubvq67iAMA==",
       "cpu": [
         "x64"
       ],
@@ -2946,9 +2916,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-freebsd-x64": {
-      "version": "0.86.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.86.0.tgz",
-      "integrity": "sha512-mc2xYRPxhzFg4NX1iqfIWP+8ORtXiNpAkaomNDepegQFlIFUmrESa3IJrKJ/4vg77Tbti7omHbraOqwdTk849g==",
+      "version": "0.80.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.80.0.tgz",
+      "integrity": "sha512-KcJ+8w/wVwd/XfDmgA9QZJAWML3vPu2O2Y8XRkf3U9VsN5n8cZ5PXMbH4NBSb3O7ctdDSvwnnuApLOz3sTHsUw==",
       "cpu": [
         "x64"
       ],
@@ -2962,9 +2932,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-arm-gnueabihf": {
-      "version": "0.86.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.86.0.tgz",
-      "integrity": "sha512-LZzapjFhwGQMKefcFsn3lJc/mTY37fBlm0jjEvETgNCyd5pH4gDwOcrp/wZHAz2qw5uLWOHaa69I6ci5lBjJgA==",
+      "version": "0.80.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.80.0.tgz",
+      "integrity": "sha512-5OCRxV5fX5RkVqsag55m4EFeudSZ0nSMYXgdtfR/5JZSiYmIYyPycafNNa52liqC2gx27vzrDRE4FdlG+5fhww==",
       "cpu": [
         "arm"
       ],
@@ -2978,9 +2948,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-arm-musleabihf": {
-      "version": "0.86.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.86.0.tgz",
-      "integrity": "sha512-/rhJMpng7/Qgn8hE4sigxTRb04+zdO0K1kfAMZ3nONphk5r2Yk2RjyEpLLz17adysCyQw/KndaMHNv8GR8VMNg==",
+      "version": "0.80.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.80.0.tgz",
+      "integrity": "sha512-kMa2PeA2GHMhvV617WdFzDAWCo2A00knPEe6rxFUO/Gr8TTLv1/LlEY6UqGseWrRfkkhFiAO496nRPW/6B5DCg==",
       "cpu": [
         "arm"
       ],
@@ -2994,9 +2964,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-arm64-gnu": {
-      "version": "0.86.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.86.0.tgz",
-      "integrity": "sha512-IXEZnk6O0zJg5gDn1Zvt5Qx62Z3E+ewrKwPgMfExqnNCLq+Ix2g7hQypevm/S6qxVgyz5HbiW+a/5ziMFXTCJQ==",
+      "version": "0.80.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.80.0.tgz",
+      "integrity": "sha512-y2NEhbFfKPdOkf3ZR/3xwJFJVji6IKxwXKHUN4bEdqpcO0tkXSCiP0MzTxjEY6ql2/MXdkqK0Ym92dYsRsgsyg==",
       "cpu": [
         "arm64"
       ],
@@ -3010,9 +2980,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-arm64-musl": {
-      "version": "0.86.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.86.0.tgz",
-      "integrity": "sha512-QG7DUVZ/AtBaUGMhgToB4glOdq0MGAEYU1MJQpNB5HqiEcOpteF9Pd+oPfscj2zrGPd47KNyljtJRBKJr6Ut0w==",
+      "version": "0.80.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.80.0.tgz",
+      "integrity": "sha512-j3tKausSXwHS/Ej6ct2dmKJtw0UIME2XJmj6QfPT6LyUSNTndj4yXRXuMSrCOrX9/0qH9GhmqeL9ouU27dQRFw==",
       "cpu": [
         "arm64"
       ],
@@ -3026,9 +2996,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-riscv64-gnu": {
-      "version": "0.86.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.86.0.tgz",
-      "integrity": "sha512-smz+J6riX2du2lp0IKeZSaOBIhhoE2N/L1IQdOLCpzB0ikjCDBoyNKdDM7te8ZDq3KDnRmJChmhQGd8P1/LGBQ==",
+      "version": "0.80.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.80.0.tgz",
+      "integrity": "sha512-h+uPvyTcpTFd946fGPU57sZeec2qHPUYQRZeXHB2uuZjps+9pxQ5zIz0EBM/JgBtnwdtoR93RAu1YNAVbqY5Zw==",
       "cpu": [
         "riscv64"
       ],
@@ -3042,9 +3012,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-s390x-gnu": {
-      "version": "0.86.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.86.0.tgz",
-      "integrity": "sha512-vas1BOMWVdicuimmi5Y+xPj3csaYQquVA45Im9a/DtVsypVeh8RWYXBMO1qJNM5Fg5HD0QvYNqxvftx3c+f5pg==",
+      "version": "0.80.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.80.0.tgz",
+      "integrity": "sha512-+u74hV+WwCPL4UBNOJaIGRozTCfZ7pM5JCEe8zAlMkKexftUzbtvW02314bVD9bqoRAL3Gg6jcZrjNjwDX2FwQ==",
       "cpu": [
         "s390x"
       ],
@@ -3058,9 +3028,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-x64-gnu": {
-      "version": "0.86.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.86.0.tgz",
-      "integrity": "sha512-3Fsi+JA3NwdZdrpC6AieOP48cuBrq0q59JgnR0mfoWfr9wHrbn2lt8EEubrj6EXpBUmu1Zii7S9NNRC6fl/d+w==",
+      "version": "0.80.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.80.0.tgz",
+      "integrity": "sha512-N9UGnWVWMlOJH+6550tqyBxd9qkMd0f4m+YRA0gly6efJTuLbPQpjkJm7pJbMu+GULcvSJ/Y0bkMAIQTtwP0vQ==",
       "cpu": [
         "x64"
       ],
@@ -3074,9 +3044,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-x64-musl": {
-      "version": "0.86.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.86.0.tgz",
-      "integrity": "sha512-89/d43EW76wJagz8u5zcKW8itB2rnS/uN7un5APb8Ebme8TePBwDyxo64J6oY5rcJYkfJ6lEszSF/ovicsNVPw==",
+      "version": "0.80.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.80.0.tgz",
+      "integrity": "sha512-l2N/GlFEri27QBMi0e53V/SlpQotIvHbz+rZZG/EO+vn58ZEr0eTG+PjJoOY/T8+TQb8nrCtRe4S/zNDpV6zSQ==",
       "cpu": [
         "x64"
       ],
@@ -3090,25 +3060,25 @@
       }
     },
     "node_modules/@oxc-parser/binding-wasm32-wasi": {
-      "version": "0.86.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.86.0.tgz",
-      "integrity": "sha512-gRrGmE2L27stNMeiAucy/ffHF9VjYr84MizuJzSYnnKmd5WXf3HelNdd0UYSJnpb7APBuyFSN2Oato+Qb6yAFw==",
+      "version": "0.80.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.80.0.tgz",
+      "integrity": "sha512-5iEwQqMXU1HiRlWuD3f+8N2O3qWhS+nOFEAWgE3sjMUnTtILPJETYhaGBPqqPWg1iRO3+hE1lEBCdI91GS1CUQ==",
       "cpu": [
         "wasm32"
       ],
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@napi-rs/wasm-runtime": "^1.0.3"
+        "@napi-rs/wasm-runtime": "^1.0.1"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@oxc-parser/binding-win32-arm64-msvc": {
-      "version": "0.86.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.86.0.tgz",
-      "integrity": "sha512-parTnpNviJYR3JIFLseDGip1KkYbhWLeuZG9OMek62gr6Omflddoytvb17s+qODoZqFAVjvuOmVipDdjTl9q3Q==",
+      "version": "0.80.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.80.0.tgz",
+      "integrity": "sha512-HedSH/Db7OFR2SugTbuawaV1vjgUjCXzxPquow/1FLtpRT2wASbMaRRbyD/h2n4DJ8V2zGqnV8Q+vic+VNvnKg==",
       "cpu": [
         "arm64"
       ],
@@ -3122,9 +3092,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-win32-x64-msvc": {
-      "version": "0.86.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.86.0.tgz",
-      "integrity": "sha512-FTso24eQh3vPTe/SOTf0/RXfjJ13tsk5fw728fm+z5y6Rb+mmEBfyVT6XxyGhEwtdfnRSZawheX74/9caI1etw==",
+      "version": "0.80.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.80.0.tgz",
+      "integrity": "sha512-SSiM0m7jG5yxVf0ivy1rF8OuTJo8ITgp1ccp2aqPZG6Qyl5QiVpf8HI1X5AvPFxts2B4Bv8U3Dip+FobqBkwcw==",
       "cpu": [
         "x64"
       ],
@@ -3138,18 +3108,18 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.86.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.86.0.tgz",
-      "integrity": "sha512-bJ57vWNQnOnUe5ZxUkrWpLyExxqb0BoyQ+IRmI/V1uxHbBNBzFGMIjKIf5ECFsgS0KgUUl8TM3a4xpeAtAnvIA==",
+      "version": "0.80.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.80.0.tgz",
+      "integrity": "sha512-xxHQm8wfCv2e8EmtaDwpMeAHOWqgQDAYg+BJouLXSQt5oTKu9TIXrgNMGSrM2fLvKmECsRd9uUFAAD+hPyootA==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
       }
     },
     "node_modules/@oxc-transform/binding-android-arm64": {
-      "version": "0.86.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-android-arm64/-/binding-android-arm64-0.86.0.tgz",
-      "integrity": "sha512-025JJoCWi04alNef6WvLnGCbx2MH9Ld2xvr0168bpOcpBjxt8sOZawu0MPrZQhnNWWiX8rrwrhuUDasWCWHxFw==",
+      "version": "0.80.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-android-arm64/-/binding-android-arm64-0.80.0.tgz",
+      "integrity": "sha512-HAK6zIUOteptOsSRqoGu41cez7kj/OPJqBGdgdP6FFh2RFcRfh0vqefjgF69af7TjzsRxVF8itiWvFsJHrIFoA==",
       "cpu": [
         "arm64"
       ],
@@ -3163,9 +3133,9 @@
       }
     },
     "node_modules/@oxc-transform/binding-darwin-arm64": {
-      "version": "0.86.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-darwin-arm64/-/binding-darwin-arm64-0.86.0.tgz",
-      "integrity": "sha512-dJls3eCO1Y2dc4zAdA+fiRbQwlvFFDmfRHRpGOllwS1FtvKQ7dMkRFKsHODEdxWakxISLvyabUmkGOhcJ47Dog==",
+      "version": "0.80.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-darwin-arm64/-/binding-darwin-arm64-0.80.0.tgz",
+      "integrity": "sha512-sVcK4tjXbCfexlhquKVcwoKQrekQWDzRXtDwOWxm3CV1k5qGUm/rl5RAQLnXYtZVgu0U2dGEct9tNms+dzbACA==",
       "cpu": [
         "arm64"
       ],
@@ -3179,9 +3149,9 @@
       }
     },
     "node_modules/@oxc-transform/binding-darwin-x64": {
-      "version": "0.86.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-darwin-x64/-/binding-darwin-x64-0.86.0.tgz",
-      "integrity": "sha512-udMZFZn6FEy36tVMs/yrczEqWyCJc+l/lqIMS4xYWsm/6qVafUWDSAZJLgcPilng16IdMnHINkc8NSz7Pp1EVw==",
+      "version": "0.80.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-darwin-x64/-/binding-darwin-x64-0.80.0.tgz",
+      "integrity": "sha512-MWmDTJszdO3X2LvbvIZocdfJnb/wjr3zhU99IlruwxsFfVNHbl03091bXi1ABsV5dyU+47V/A5jG3xOtg5X0vQ==",
       "cpu": [
         "x64"
       ],
@@ -3195,9 +3165,9 @@
       }
     },
     "node_modules/@oxc-transform/binding-freebsd-x64": {
-      "version": "0.86.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-freebsd-x64/-/binding-freebsd-x64-0.86.0.tgz",
-      "integrity": "sha512-41J5qSlypbE0HCOd+4poFD96+ZKoR8sfDn5qdaU0Hc5bT5Drwat/wv06s9Y5Lu86uXYTwPPj6kbbxHHsiV2irw==",
+      "version": "0.80.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-freebsd-x64/-/binding-freebsd-x64-0.80.0.tgz",
+      "integrity": "sha512-fKuwj/iBfjfGePjcR9+j2TQ/7RlrUIT4ir/OAcHWYJ/kvxp4XY/juKYXo4lks/MW/dwe+UR1Lp6xiCQBuxpyIg==",
       "cpu": [
         "x64"
       ],
@@ -3211,9 +3181,9 @@
       }
     },
     "node_modules/@oxc-transform/binding-linux-arm-gnueabihf": {
-      "version": "0.86.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.86.0.tgz",
-      "integrity": "sha512-mrI+nKgwRsr4FYjb0pECrNTVnNvHAflukS3SFqFHI8n+3LJgrCYDcnbrFD/4VWKp2EUrkIZ//RhwgGsTiSXbng==",
+      "version": "0.80.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.80.0.tgz",
+      "integrity": "sha512-R0QdfKiV+ZFiM28UnyylOEtTBFjAb4XuHvQltUSUpylXXIbGd+0Z1WF5lY3Z776Vy00HWhYj/Vo03rhvjdVDTA==",
       "cpu": [
         "arm"
       ],
@@ -3227,9 +3197,9 @@
       }
     },
     "node_modules/@oxc-transform/binding-linux-arm-musleabihf": {
-      "version": "0.86.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.86.0.tgz",
-      "integrity": "sha512-FXWyvpxiEXBewA3L6HGFtEribqFjGOiounD8ke/4C1F5134+rH5rNrgK6vY116P4MtWKfZolMRdvlzaD3TaX0A==",
+      "version": "0.80.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.80.0.tgz",
+      "integrity": "sha512-hIfp4LwyQMRhsY9ptx4UleffoY9wZofTmnHFhZTMdb/hoE97Vuqw7Ub2cLcWMu0FYHIX8zXCMd1CJjs2MV1X3w==",
       "cpu": [
         "arm"
       ],
@@ -3243,9 +3213,9 @@
       }
     },
     "node_modules/@oxc-transform/binding-linux-arm64-gnu": {
-      "version": "0.86.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.86.0.tgz",
-      "integrity": "sha512-gktU/9WLAc0d2hAq8yRi3K92xwkWoDt1gJmokMOfb1FU4fyDbzbt13jdZEd6KVn2xLaiQeaFTTfFTghFsJUM3A==",
+      "version": "0.80.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.80.0.tgz",
+      "integrity": "sha512-mOYGji1m55BD2vV5m1qnrXbdqyPp/AU9p1Rn+0hM2zkE3pVkETCPvLevSvt4rHQZBZFIWeRGo47QNsNQyaZBsg==",
       "cpu": [
         "arm64"
       ],
@@ -3259,9 +3229,9 @@
       }
     },
     "node_modules/@oxc-transform/binding-linux-arm64-musl": {
-      "version": "0.86.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.86.0.tgz",
-      "integrity": "sha512-2w5e5qiTBYQ0xc1aSY1GNyAOP9BQFEjN43FI3OhrRWZXHOj3inqcVSlptO/hHGK3Q2bG26kWLfSNFOEylTX39A==",
+      "version": "0.80.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.80.0.tgz",
+      "integrity": "sha512-kBBCQwr1GCkr/b0iXH+ijsg+CSPCAMSV2tu4LmG2PFaxBnZilMYfUyWHCAiskbbUADikecUfwX6hHIaQoMaixg==",
       "cpu": [
         "arm64"
       ],
@@ -3275,9 +3245,9 @@
       }
     },
     "node_modules/@oxc-transform/binding-linux-riscv64-gnu": {
-      "version": "0.86.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.86.0.tgz",
-      "integrity": "sha512-PfnTYm+vQ9X5VNXqs0Z3S67Xp2FoZj5RteYKUNwL+j/sxGi05eps+EWLVrcGsuN9x2GHFpTiqBz3lzERCn2USg==",
+      "version": "0.80.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.80.0.tgz",
+      "integrity": "sha512-8CGJhHoD2Ttw8HtCNd/IWnGtL0Nsn448L2hZJtbDDGVUZUF4bbZFdXPnRt0QrEbupywoH6InN6q2imLous6xnw==",
       "cpu": [
         "riscv64"
       ],
@@ -3291,9 +3261,9 @@
       }
     },
     "node_modules/@oxc-transform/binding-linux-s390x-gnu": {
-      "version": "0.86.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.86.0.tgz",
-      "integrity": "sha512-uHgGN0rFfqDcdkLUITshqrpV34PRKAiRwsw6Jgkg7CRcRGIU8rOJc568EU0jfhTZ1zO5MJKt/S8D6cgIFJwe0A==",
+      "version": "0.80.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.80.0.tgz",
+      "integrity": "sha512-V/Lb6m5loWzvdB/qo6eYvVXidQku/PA706JbeE/PPCup8At+BwOXnZjktv7LDxrpuqnO32tZDHUUc9Y3bzOEBw==",
       "cpu": [
         "s390x"
       ],
@@ -3307,9 +3277,9 @@
       }
     },
     "node_modules/@oxc-transform/binding-linux-x64-gnu": {
-      "version": "0.86.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.86.0.tgz",
-      "integrity": "sha512-MtrvfU2RkSD+oTnzG4Xle3jK8FXJPQa1MhYQm0ivcAMf0tUQDojTaqBtM/9E0iFr/4l1xZODJOHCGjLktdpykg==",
+      "version": "0.80.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.80.0.tgz",
+      "integrity": "sha512-03hHW04MQNb+ak27xo79nUkMjVu6146TNgeSapcDRATH4R0YMmXB2oPQK1K2nuBJzVZjBjH7Bus/I7tR3JasAg==",
       "cpu": [
         "x64"
       ],
@@ -3323,9 +3293,9 @@
       }
     },
     "node_modules/@oxc-transform/binding-linux-x64-musl": {
-      "version": "0.86.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-x64-musl/-/binding-linux-x64-musl-0.86.0.tgz",
-      "integrity": "sha512-wTTTIPcnoS04SRJ7HuOL/VxIu1QzUtv2n6Mx0wPIEQobj2qPGum0qYGnFEMU0Njltp+8FAUg5EfX6u3udRQBbQ==",
+      "version": "0.80.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-x64-musl/-/binding-linux-x64-musl-0.80.0.tgz",
+      "integrity": "sha512-BkXniuuHpo9cR2S3JDKIvmUrNvmm335owGW4rfp07HjVUsbq9e7bSnvOnyA3gXGdrPR2IgCWGi5nnXk2NN5Q0A==",
       "cpu": [
         "x64"
       ],
@@ -3339,25 +3309,25 @@
       }
     },
     "node_modules/@oxc-transform/binding-wasm32-wasi": {
-      "version": "0.86.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-wasm32-wasi/-/binding-wasm32-wasi-0.86.0.tgz",
-      "integrity": "sha512-g+0bf+ZA2DvBHQ+0u8TvEY8ERo86Brqvdghfv06Wph2qGTlhzSmrE0c0Zurr7yhtqI5yZjMaBr2HbqwW1kHFng==",
+      "version": "0.80.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-wasm32-wasi/-/binding-wasm32-wasi-0.80.0.tgz",
+      "integrity": "sha512-jfRRXLtfSgTeJXBHj6qb+HHUd6hmYcyUNMBcTY8/k+JVsx0ThfrmCIufNlSJTt1zB+ugnMVMuQGeB0oF+aa86w==",
       "cpu": [
         "wasm32"
       ],
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@napi-rs/wasm-runtime": "^1.0.3"
+        "@napi-rs/wasm-runtime": "^1.0.1"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@oxc-transform/binding-win32-arm64-msvc": {
-      "version": "0.86.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.86.0.tgz",
-      "integrity": "sha512-dgBeU4qBEag0rhW3OT9YHgj4cvW51KZzrxhDQ1gAVX2fqgl+CeJnu0a9q+DMhefHrO3c8Yxwbt7NxUDmWGkEtg==",
+      "version": "0.80.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.80.0.tgz",
+      "integrity": "sha512-bofcVhlAV1AKzbE0TgDH+h813pbwWwwRhN6tv/hD4qEuWh/qEjv8Xb3Ar15xfBfyLI53FoJascuaJAFzX+IN9A==",
       "cpu": [
         "arm64"
       ],
@@ -3371,9 +3341,9 @@
       }
     },
     "node_modules/@oxc-transform/binding-win32-x64-msvc": {
-      "version": "0.86.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.86.0.tgz",
-      "integrity": "sha512-M1eCl8xz7MmEatuqWdr+VdvNCUJ+d4ECF+HND39PqRCVkaH+Vl1rcyP5pLILb2CB/wTb2DMvZmb9RCt5+8S5TQ==",
+      "version": "0.80.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.80.0.tgz",
+      "integrity": "sha512-MT6hQo9Kw/VuQUfX0fc0OpUdZesQruT0UNY9hxIcqcli7pbxMrvFBjkXo7oUb2151s/n+F4fyQOWvaR6zwxtDA==",
       "cpu": [
         "x64"
       ],
@@ -5118,16 +5088,33 @@
       "license": "MIT"
     },
     "node_modules/@volar/typescript": {
-      "version": "2.4.23",
-      "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.4.23.tgz",
-      "integrity": "sha512-lAB5zJghWxVPqfcStmAP1ZqQacMpe90UrP5RJ3arDyrhy4aCUQqmxPPLB2PWDKugvylmO41ljK7vZ+t6INMTag==",
+      "version": "2.4.15",
+      "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.4.15.tgz",
+      "integrity": "sha512-2aZ8i0cqPGjXb4BhkMsPYDkkuc2ZQ6yOpqwAuNwUoncELqoy5fRgOQtLR9gB0g902iS0NAkvpIzs27geVyVdPg==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@volar/language-core": "2.4.23",
+        "@volar/language-core": "2.4.15",
         "path-browserify": "^1.0.1",
         "vscode-uri": "^3.0.8"
       }
+    },
+    "node_modules/@volar/typescript/node_modules/@volar/language-core": {
+      "version": "2.4.15",
+      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.15.tgz",
+      "integrity": "sha512-3VHw+QZU0ZG9IuQmzT68IyN4hZNd9GchGPhbD9+pa8CVv7rnoOZwo7T8weIbrRmihqy3ATpdfXFnqRrfPVK6CA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/source-map": "2.4.15"
+      }
+    },
+    "node_modules/@volar/typescript/node_modules/@volar/source-map": {
+      "version": "2.4.15",
+      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.15.tgz",
+      "integrity": "sha512-CPbMWlUN6hVZJYGcU/GSoHu4EnCHiLaXI9n8c9la6RaI9W5JHX+NqG+GSQcB0JdC2FIBLdZJwGsfKyBB71VlTg==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/@vue-macros/common": {
       "version": "3.0.0-beta.16",
@@ -7228,7 +7215,6 @@
       "version": "5.18.3",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.3.tgz",
       "integrity": "sha512-d4lC8xfavMeBjzGr2vECC3fsGXziXZQyJxD868h2M/mBI3PwAuODxAkLkq5HYuvrPYcUtiLzsTo8U3PgX3Ocww==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
@@ -7533,6 +7519,24 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.7.tgz",
       "integrity": "sha512-VO5fQUzZtI6C+vx4w/4BWJpg3s/5l+6pRQEHzFRM8WFi4XffSP1Z+4qi7GbjWbvRQEbdIco5mIMq+zX4rPuLrw==",
+      "license": "MIT"
+    },
+    "node_modules/externality": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/externality/-/externality-1.0.2.tgz",
+      "integrity": "sha512-LyExtJWKxtgVzmgtEHyQtLFpw1KFhQphF9nTG8TpAIVkiI/xQ3FJh75tRFLYl4hkn7BNIIdLJInuDAavX35pMw==",
+      "license": "MIT",
+      "dependencies": {
+        "enhanced-resolve": "^5.14.1",
+        "mlly": "^1.3.0",
+        "pathe": "^1.1.1",
+        "ufo": "^1.1.2"
+      }
+    },
+    "node_modules/externality/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
       "license": "MIT"
     },
     "node_modules/extract-zip": {
@@ -10016,20 +10020,20 @@
       }
     },
     "node_modules/nuxt": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/nuxt/-/nuxt-4.1.0.tgz",
-      "integrity": "sha512-bnHWcztOrxjBMcoiqO51cVR0kzycohTazrdEVgL2I6U5gCX3R63XWP+PQ2itO/DCdZPP5i9ZF9HsJGXYbc5w/g==",
+      "version": "3.18.1",
+      "resolved": "https://registry.npmjs.org/nuxt/-/nuxt-3.18.1.tgz",
+      "integrity": "sha512-y2pLKty6R8MCCFlAUsJNJcOuT6M3EovzEpi7/U3WXQsnzf2MzP+5I67ScfmwSqZ3UUMgXvfc9H4+KC4Ifnq5wg==",
       "license": "MIT",
       "dependencies": {
-        "@nuxt/cli": "^3.28.0",
+        "@nuxt/cli": "^3.27.0",
         "@nuxt/devalue": "^2.0.2",
-        "@nuxt/devtools": "^2.6.3",
-        "@nuxt/kit": "4.1.0",
-        "@nuxt/schema": "4.1.0",
+        "@nuxt/devtools": "^2.6.2",
+        "@nuxt/kit": "3.18.1",
+        "@nuxt/schema": "3.18.1",
         "@nuxt/telemetry": "^2.6.6",
-        "@nuxt/vite-builder": "4.1.0",
-        "@unhead/vue": "^2.0.14",
-        "@vue/shared": "^3.5.20",
+        "@nuxt/vite-builder": "3.18.1",
+        "@unhead/vue": "^2.0.13",
+        "@vue/shared": "^3.5.18",
         "c12": "^3.2.0",
         "chokidar": "^4.0.3",
         "compatx": "^0.2.0",
@@ -10037,9 +10041,9 @@
         "cookie-es": "^2.0.0",
         "defu": "^6.1.4",
         "destr": "^2.0.5",
-        "devalue": "^5.3.2",
+        "devalue": "^5.1.1",
         "errx": "^0.1.0",
-        "esbuild": "^0.25.9",
+        "esbuild": "^0.25.8",
         "escape-string-regexp": "^5.0.0",
         "estree-walker": "^3.0.3",
         "exsolve": "^1.0.7",
@@ -10050,8 +10054,8 @@
         "jiti": "^2.5.1",
         "klona": "^2.0.6",
         "knitwork": "^1.2.0",
-        "magic-string": "^0.30.18",
-        "mlly": "^1.8.0",
+        "magic-string": "^0.30.17",
+        "mlly": "^1.7.4",
         "mocked-exports": "^0.1.1",
         "nanotar": "^0.2.0",
         "nitropack": "^2.12.4",
@@ -10059,13 +10063,13 @@
         "ofetch": "^1.4.1",
         "ohash": "^2.0.11",
         "on-change": "^5.0.1",
-        "oxc-minify": "^0.86.0",
-        "oxc-parser": "^0.86.0",
-        "oxc-transform": "^0.86.0",
+        "oxc-minify": "^0.80.0",
+        "oxc-parser": "^0.80.0",
+        "oxc-transform": "^0.80.0",
         "oxc-walker": "^0.4.0",
         "pathe": "^2.0.3",
-        "perfect-debounce": "^2.0.0",
-        "pkg-types": "^2.3.0",
+        "perfect-debounce": "^1.0.0",
+        "pkg-types": "^2.2.0",
         "radix3": "^1.1.2",
         "scule": "^1.3.0",
         "semver": "^7.7.2",
@@ -10077,11 +10081,11 @@
         "uncrypto": "^0.1.3",
         "unctx": "^2.4.1",
         "unimport": "^5.2.0",
-        "unplugin": "^2.3.10",
+        "unplugin": "^2.3.5",
         "unplugin-vue-router": "^0.15.0",
-        "unstorage": "^1.17.0",
+        "unstorage": "^1.16.1",
         "untyped": "^2.0.0",
-        "vue": "^3.5.20",
+        "vue": "^3.5.18",
         "vue-bundle-renderer": "^2.1.2",
         "vue-devtools-stub": "^0.1.0",
         "vue-router": "^4.5.1"
@@ -10095,7 +10099,7 @@
       },
       "peerDependencies": {
         "@parcel/watcher": "^2.1.0",
-        "@types/node": ">=18.12.0"
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0"
       },
       "peerDependenciesMeta": {
         "@parcel/watcher": {
@@ -10121,49 +10125,10 @@
         "vue-qrcode-reader": "^5.7.2"
       }
     },
-    "node_modules/nuxt/node_modules/@nuxt/kit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-4.1.0.tgz",
-      "integrity": "sha512-QY6wgano7szNP5hLUKNeZTLdx009F2n+a8L9M4Wzk1jhubvENc81jLWHAnaJOogRpqMeEqZcjHRfqTx+J1/lfQ==",
-      "license": "MIT",
-      "dependencies": {
-        "c12": "^3.2.0",
-        "consola": "^3.4.2",
-        "defu": "^6.1.4",
-        "destr": "^2.0.5",
-        "errx": "^0.1.0",
-        "exsolve": "^1.0.7",
-        "ignore": "^7.0.5",
-        "jiti": "^2.5.1",
-        "klona": "^2.0.6",
-        "mlly": "^1.8.0",
-        "ohash": "^2.0.11",
-        "pathe": "^2.0.3",
-        "pkg-types": "^2.3.0",
-        "rc9": "^2.1.2",
-        "scule": "^1.3.0",
-        "semver": "^7.7.2",
-        "std-env": "^3.9.0",
-        "tinyglobby": "^0.2.14",
-        "ufo": "^1.6.1",
-        "unctx": "^2.4.1",
-        "unimport": "^5.2.0",
-        "untyped": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=18.12.0"
-      }
-    },
     "node_modules/nuxt/node_modules/cookie-es": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-2.0.0.tgz",
       "integrity": "sha512-RAj4E421UYRgqokKUmotqAwuplYw15qtdXfY+hGzgCJ/MBjCVZcSoHK/kH9kocfjRjcDME7IiDWR/1WX1TM2Pg==",
-      "license": "MIT"
-    },
-    "node_modules/nuxt/node_modules/perfect-debounce": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-2.0.0.tgz",
-      "integrity": "sha512-fkEH/OBiKrqqI/yIgjR92lMfs2K8105zt/VT6+7eTjNwisrsh47CeIED9z58zI7DfKdH3uHAn25ziRZn3kgAow==",
       "license": "MIT"
     },
     "node_modules/nypm": {
@@ -10322,9 +10287,9 @@
       }
     },
     "node_modules/oxc-minify": {
-      "version": "0.86.0",
-      "resolved": "https://registry.npmjs.org/oxc-minify/-/oxc-minify-0.86.0.tgz",
-      "integrity": "sha512-pjtM94KElw/RxF3R1ls1ADcBUyZcrCgn0qeL4nD8cOotfzeVFa0xXwQQeCkk+5GPiOqdRApNFuJvK//lQgpqJw==",
+      "version": "0.80.0",
+      "resolved": "https://registry.npmjs.org/oxc-minify/-/oxc-minify-0.80.0.tgz",
+      "integrity": "sha512-kMMb3dC8KlQ+Bzf/UhepYsq1ukorCOJu038rSxF7kTbsCLx1Ojet9Hc9gKqKR/Wpih5GWnOA2DvLe20ZtxbJ2Q==",
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
@@ -10333,30 +10298,30 @@
         "url": "https://github.com/sponsors/Boshen"
       },
       "optionalDependencies": {
-        "@oxc-minify/binding-android-arm64": "0.86.0",
-        "@oxc-minify/binding-darwin-arm64": "0.86.0",
-        "@oxc-minify/binding-darwin-x64": "0.86.0",
-        "@oxc-minify/binding-freebsd-x64": "0.86.0",
-        "@oxc-minify/binding-linux-arm-gnueabihf": "0.86.0",
-        "@oxc-minify/binding-linux-arm-musleabihf": "0.86.0",
-        "@oxc-minify/binding-linux-arm64-gnu": "0.86.0",
-        "@oxc-minify/binding-linux-arm64-musl": "0.86.0",
-        "@oxc-minify/binding-linux-riscv64-gnu": "0.86.0",
-        "@oxc-minify/binding-linux-s390x-gnu": "0.86.0",
-        "@oxc-minify/binding-linux-x64-gnu": "0.86.0",
-        "@oxc-minify/binding-linux-x64-musl": "0.86.0",
-        "@oxc-minify/binding-wasm32-wasi": "0.86.0",
-        "@oxc-minify/binding-win32-arm64-msvc": "0.86.0",
-        "@oxc-minify/binding-win32-x64-msvc": "0.86.0"
+        "@oxc-minify/binding-android-arm64": "0.80.0",
+        "@oxc-minify/binding-darwin-arm64": "0.80.0",
+        "@oxc-minify/binding-darwin-x64": "0.80.0",
+        "@oxc-minify/binding-freebsd-x64": "0.80.0",
+        "@oxc-minify/binding-linux-arm-gnueabihf": "0.80.0",
+        "@oxc-minify/binding-linux-arm-musleabihf": "0.80.0",
+        "@oxc-minify/binding-linux-arm64-gnu": "0.80.0",
+        "@oxc-minify/binding-linux-arm64-musl": "0.80.0",
+        "@oxc-minify/binding-linux-riscv64-gnu": "0.80.0",
+        "@oxc-minify/binding-linux-s390x-gnu": "0.80.0",
+        "@oxc-minify/binding-linux-x64-gnu": "0.80.0",
+        "@oxc-minify/binding-linux-x64-musl": "0.80.0",
+        "@oxc-minify/binding-wasm32-wasi": "0.80.0",
+        "@oxc-minify/binding-win32-arm64-msvc": "0.80.0",
+        "@oxc-minify/binding-win32-x64-msvc": "0.80.0"
       }
     },
     "node_modules/oxc-parser": {
-      "version": "0.86.0",
-      "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.86.0.tgz",
-      "integrity": "sha512-v9+uomgqyLSxlq3qlaMqJJtXg2+rUsa368p/zkmgi5OMGmcZAtZt5GIeSVFF84iNET+08Hdx/rUtd/FyIdfNFQ==",
+      "version": "0.80.0",
+      "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.80.0.tgz",
+      "integrity": "sha512-lTEUQs+WBOXPUzMR/tWY4yT9D7xXwnENtRR7Epw/QcuYpV4fRveEA+zq8IGUwyyuWecl8jHrddCCuadw+kZOSA==",
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "^0.86.0"
+        "@oxc-project/types": "^0.80.0"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -10365,27 +10330,27 @@
         "url": "https://github.com/sponsors/Boshen"
       },
       "optionalDependencies": {
-        "@oxc-parser/binding-android-arm64": "0.86.0",
-        "@oxc-parser/binding-darwin-arm64": "0.86.0",
-        "@oxc-parser/binding-darwin-x64": "0.86.0",
-        "@oxc-parser/binding-freebsd-x64": "0.86.0",
-        "@oxc-parser/binding-linux-arm-gnueabihf": "0.86.0",
-        "@oxc-parser/binding-linux-arm-musleabihf": "0.86.0",
-        "@oxc-parser/binding-linux-arm64-gnu": "0.86.0",
-        "@oxc-parser/binding-linux-arm64-musl": "0.86.0",
-        "@oxc-parser/binding-linux-riscv64-gnu": "0.86.0",
-        "@oxc-parser/binding-linux-s390x-gnu": "0.86.0",
-        "@oxc-parser/binding-linux-x64-gnu": "0.86.0",
-        "@oxc-parser/binding-linux-x64-musl": "0.86.0",
-        "@oxc-parser/binding-wasm32-wasi": "0.86.0",
-        "@oxc-parser/binding-win32-arm64-msvc": "0.86.0",
-        "@oxc-parser/binding-win32-x64-msvc": "0.86.0"
+        "@oxc-parser/binding-android-arm64": "0.80.0",
+        "@oxc-parser/binding-darwin-arm64": "0.80.0",
+        "@oxc-parser/binding-darwin-x64": "0.80.0",
+        "@oxc-parser/binding-freebsd-x64": "0.80.0",
+        "@oxc-parser/binding-linux-arm-gnueabihf": "0.80.0",
+        "@oxc-parser/binding-linux-arm-musleabihf": "0.80.0",
+        "@oxc-parser/binding-linux-arm64-gnu": "0.80.0",
+        "@oxc-parser/binding-linux-arm64-musl": "0.80.0",
+        "@oxc-parser/binding-linux-riscv64-gnu": "0.80.0",
+        "@oxc-parser/binding-linux-s390x-gnu": "0.80.0",
+        "@oxc-parser/binding-linux-x64-gnu": "0.80.0",
+        "@oxc-parser/binding-linux-x64-musl": "0.80.0",
+        "@oxc-parser/binding-wasm32-wasi": "0.80.0",
+        "@oxc-parser/binding-win32-arm64-msvc": "0.80.0",
+        "@oxc-parser/binding-win32-x64-msvc": "0.80.0"
       }
     },
     "node_modules/oxc-transform": {
-      "version": "0.86.0",
-      "resolved": "https://registry.npmjs.org/oxc-transform/-/oxc-transform-0.86.0.tgz",
-      "integrity": "sha512-Ghgm/zzjPXROMpljLy4HYBcko/25sixWi2yJQJ6rDu/ltgFB1nEQ4JYCYV5F+ENt0McsJkcgmX5I4dRfDViyDA==",
+      "version": "0.80.0",
+      "resolved": "https://registry.npmjs.org/oxc-transform/-/oxc-transform-0.80.0.tgz",
+      "integrity": "sha512-hWusSpynsn4MZP1KJa7e254xyVmowTUshvttpk7JfTt055YEJ+ad6memMJ9GJqPeeyydfnwwKkLy6eiwDn12xA==",
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
@@ -10394,21 +10359,21 @@
         "url": "https://github.com/sponsors/Boshen"
       },
       "optionalDependencies": {
-        "@oxc-transform/binding-android-arm64": "0.86.0",
-        "@oxc-transform/binding-darwin-arm64": "0.86.0",
-        "@oxc-transform/binding-darwin-x64": "0.86.0",
-        "@oxc-transform/binding-freebsd-x64": "0.86.0",
-        "@oxc-transform/binding-linux-arm-gnueabihf": "0.86.0",
-        "@oxc-transform/binding-linux-arm-musleabihf": "0.86.0",
-        "@oxc-transform/binding-linux-arm64-gnu": "0.86.0",
-        "@oxc-transform/binding-linux-arm64-musl": "0.86.0",
-        "@oxc-transform/binding-linux-riscv64-gnu": "0.86.0",
-        "@oxc-transform/binding-linux-s390x-gnu": "0.86.0",
-        "@oxc-transform/binding-linux-x64-gnu": "0.86.0",
-        "@oxc-transform/binding-linux-x64-musl": "0.86.0",
-        "@oxc-transform/binding-wasm32-wasi": "0.86.0",
-        "@oxc-transform/binding-win32-arm64-msvc": "0.86.0",
-        "@oxc-transform/binding-win32-x64-msvc": "0.86.0"
+        "@oxc-transform/binding-android-arm64": "0.80.0",
+        "@oxc-transform/binding-darwin-arm64": "0.80.0",
+        "@oxc-transform/binding-darwin-x64": "0.80.0",
+        "@oxc-transform/binding-freebsd-x64": "0.80.0",
+        "@oxc-transform/binding-linux-arm-gnueabihf": "0.80.0",
+        "@oxc-transform/binding-linux-arm-musleabihf": "0.80.0",
+        "@oxc-transform/binding-linux-arm64-gnu": "0.80.0",
+        "@oxc-transform/binding-linux-arm64-musl": "0.80.0",
+        "@oxc-transform/binding-linux-riscv64-gnu": "0.80.0",
+        "@oxc-transform/binding-linux-s390x-gnu": "0.80.0",
+        "@oxc-transform/binding-linux-x64-gnu": "0.80.0",
+        "@oxc-transform/binding-linux-x64-musl": "0.80.0",
+        "@oxc-transform/binding-wasm32-wasi": "0.80.0",
+        "@oxc-transform/binding-win32-arm64-msvc": "0.80.0",
+        "@oxc-transform/binding-win32-x64-msvc": "0.80.0"
       }
     },
     "node_modules/oxc-walker": {
@@ -12484,7 +12449,6 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.3.tgz",
       "integrity": "sha512-ZL6DDuAlRlLGghwcfmSn9sK3Hr6ArtyudlSAiCqQ6IfE+b+HHbydbYDIG15IfS5do+7XQQBdBiubF/cV2dnDzg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -13713,20 +13677,85 @@
       }
     },
     "node_modules/vue-tsc": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-3.0.6.tgz",
-      "integrity": "sha512-Tbs8Whd43R2e2nxez4WXPvvdjGbW24rOSgRhLOHXzWiT4pcP4G7KeWh0YCn18rF4bVwv7tggLLZ6MJnO6jXPBg==",
+      "version": "2.2.12",
+      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-2.2.12.tgz",
+      "integrity": "sha512-P7OP77b2h/Pmk+lZdJ0YWs+5tJ6J2+uOQPo7tlBnY44QqQSPYvS0qVT4wqDJgwrZaLe47etJLLQRFia71GYITw==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@volar/typescript": "2.4.23",
-        "@vue/language-core": "3.0.6"
+        "@volar/typescript": "2.4.15",
+        "@vue/language-core": "2.2.12"
       },
       "bin": {
         "vue-tsc": "bin/vue-tsc.js"
       },
       "peerDependencies": {
         "typescript": ">=5.0.0"
+      }
+    },
+    "node_modules/vue-tsc/node_modules/@volar/language-core": {
+      "version": "2.4.15",
+      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.15.tgz",
+      "integrity": "sha512-3VHw+QZU0ZG9IuQmzT68IyN4hZNd9GchGPhbD9+pa8CVv7rnoOZwo7T8weIbrRmihqy3ATpdfXFnqRrfPVK6CA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/source-map": "2.4.15"
+      }
+    },
+    "node_modules/vue-tsc/node_modules/@volar/source-map": {
+      "version": "2.4.15",
+      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.15.tgz",
+      "integrity": "sha512-CPbMWlUN6hVZJYGcU/GSoHu4EnCHiLaXI9n8c9la6RaI9W5JHX+NqG+GSQcB0JdC2FIBLdZJwGsfKyBB71VlTg==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/vue-tsc/node_modules/@vue/language-core": {
+      "version": "2.2.12",
+      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-2.2.12.tgz",
+      "integrity": "sha512-IsGljWbKGU1MZpBPN+BvPAdr55YPkj2nB/TBNGNC32Vy2qLG25DYu/NBN2vNtZqdRbTRjaoYrahLrToim2NanA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/language-core": "2.4.15",
+        "@vue/compiler-dom": "^3.5.0",
+        "@vue/compiler-vue2": "^2.7.16",
+        "@vue/shared": "^3.5.0",
+        "alien-signals": "^1.0.3",
+        "minimatch": "^9.0.3",
+        "muggle-string": "^0.4.1",
+        "path-browserify": "^1.0.1"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vue-tsc/node_modules/alien-signals": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-1.0.13.tgz",
+      "integrity": "sha512-OGj9yyTnJEttvzhTUWuscOvtqxq5vrhF7vL9oS0xJ2mK0ItPYP1/y+vCFebfxoEyAz0++1AIwJ5CMr+Fk3nDmg==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/vue-tsc/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "devOptional": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/web-streams-polyfill": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@heroicons/vue": "^2.2.0",
     "jimp": "^1.6.0",
     "jose": "^6.0.11",
-    "nuxt": "^4.0.0",
+    "nuxt": "^3.17.5",
     "vue": "^3.5.16",
     "qrcode-reader": "^1.0.4",
     "vue-router": "^4.5.1"
@@ -34,7 +34,7 @@
     "tailwindcss": "4.1.13",
     "typescript": "5.9.2",
     "vitest": "3.2.4",
-    "vue-tsc": "3.0.6"
+    "vue-tsc": "2.2.12"
   },
   "version": "0.0.3"
 }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@tailwindcss/forms": "0.5.10",
     "@vue/test-utils": "2.4.6",
     "autoprefixer": "10.4.21",
-    "nuxt-qrcode": "0.4.7",
+    "nuxt-qrcode": "0.4.6",
     "happy-dom": "18.0.1",
     "postcss": "8.5.6",
     "tailwindcss": "4.1.13",


### PR DESCRIPTION
We have found the test suite to be unstable under version 4 of Nuxt and
need to revert to the previous version.

Command used:

	./development/until_failure.sh 'npm run test:once'

For version 4 we consistently failed within 10 attempts. Version 3.x ran
100 consequtive attempts without failure.

We have found no reported issues in the official Nuxt issue tracker
regarding this problem.

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
