### PR TITLE
fix: bump reusable integration workflow

### DIFF
--- a/.github/workflows/ecosystem-integration.yml
+++ b/.github/workflows/ecosystem-integration.yml
@@ -21,8 +21,7 @@ concurrency:
 jobs:
   integration-test:
     # Use the specific commit hash from the wallet-ecosystem repository for stability.
-    # This hash corresponds to the merge of the reusable integration workflow into main.
-    uses: diggsweden/wallet-ecosystem/.github/workflows/reusable-integration.yml@9a976535c61fce3e1f3acd7f7e91833aabee09de
+    uses: diggsweden/wallet-ecosystem/.github/workflows/reusable-integration.yml@c6548a93878f74cae1aaf756dd2f8efcda102b88
     with:
       service-name: demo-verifier
       service-repo: ${{ github.repository }}


### PR DESCRIPTION
Here we change to a version of the reusable integration workflow that fixes an issue with the ecosystem startup.

See: https://github.com/diggsweden/wallet-ecosystem/commit/c6548a93878f74cae1aaf756dd2f8efcda102b88

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
